### PR TITLE
Fix includes for musl on linux aarch64

### DIFF
--- a/hotspot/src/os_cpu/linux_aarch64/vm/os_linux_aarch64.cpp
+++ b/hotspot/src/os_cpu/linux_aarch64/vm/os_linux_aarch64.cpp
@@ -73,7 +73,7 @@
 # include <poll.h>
 # include <ucontext.h>
 
-#ifdef MUSL_LIBC
+#ifndef MUSL_LIBC
 #include <fpu_control.h>
 #else
 #include <linux/types.h>  /* provides __u64 */


### PR DESCRIPTION
Small fix in includes for Alpine Linux support on aarch64
Link to test pipeline: https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-alpine-linux-aarch64-temurin/11/ 